### PR TITLE
Link to tutorial hosted at ReadTheDocs

### DIFF
--- a/templates/console.htm
+++ b/templates/console.htm
@@ -5,7 +5,7 @@
         <div class="panel-body">
           <p><a href="http://www.idris-lang.org/">Idris</a> is a
           language for practical, dependently typed, functional
-          programming. The <a href="http://eb.host.cs.st-andrews.ac.uk/writings/idris-tutorial.pdf">Idris
+          programming. The <a href="http://idris.readthedocs.org/en/latest/tutorial/index.html#tutorial-index">Idris
           Tutorial</a> is the best resource for becoming familiar with
           the language. You can use
           the <a href="https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop">REPL</a>


### PR DESCRIPTION
The PDF tutorial has been [deprecated](https://github.com/idris-lang/idris-tutorial/blob/master/README.md). This PR updates the tutorial href to point to the tutorial's new location.

As a side benefit, the HTML version is far more friendly for reading on a phone screen.